### PR TITLE
Fix IIIFv2 `AnnotationList` type prefix from `oa:` to `sc:`

### DIFF
--- a/src/presentation-2/traverse.ts
+++ b/src/presentation-2/traverse.ts
@@ -24,7 +24,7 @@ export const types: TraversableEntityTypes[] = [
   'sc:Collection',
   'sc:Manifest',
   'sc:Canvas',
-  'oa:AnnotationList',
+  'sc:AnnotationList',
   'oa:Annotation',
   'sc:Range',
   'sc:Layer',


### PR DESCRIPTION
This seems to have been a misreading of the IIIFv2 spec, which clearly states that an annotation list must have the type `sc:AnnotationList`.